### PR TITLE
Refactors code, mainly by making simulate() not take psi_re or psi_im…

### DIFF
--- a/numerical_exercise.ipynb
+++ b/numerical_exercise.ipynb
@@ -92,7 +92,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def generate_psi(num_iter=num_iter, N=N):\n",
+    "# Yo, Knært, jeg orket ikke tenke på hvor man burde plassere ting, så la den her. Kanskje dust, men den må hvertfall være før generate_psi()\n",
+    "''' Problem 1'''\n",
+    "x_s = 5 # Start position\n",
+    "x_f = L/2 + x_s # final position, later we will let the wave propagate til it reaches here, ellerno\n",
+    "sigma_x = 1.5\n",
+    "\n",
+    "# Normalization\n",
+    "C = 1/np.sqrt(\n",
+    "    np.sum(np.exp(-(x-x_s)**2/(sigma_x**2)))*dx\n",
+    ")\n",
+    "\n",
+    "v = np.zeros(N) # Zero potential\n",
+    "dt = 0.1 * h_bar / (h_bar**2 /(2*m*dx**2) + np.max(v)) # Timestep, much smaller than ..., see (12)\n",
+    "\n",
+    "'''Parameters for propagation'''\n",
+    "v_g = h_bar*k_0/m # group velocity\n",
+    "sim_time = L/(2*v_g) # simulation time\n",
+    "num_iter = int(sim_time/dt) # number of iterations\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def generate_psi(x_s=x_s, sigma_x=sigma_x, num_iter=num_iter, N=N):\n",
     "    \"\"\"Generates inital values for psi\n",
     "    Returns:\n",
     "        psi_re\n",
@@ -122,24 +148,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "''' Problem 1'''\n",
-    "x_s = 5 # Start position\n",
-    "x_f = L/2 + x_s # final position, later we will let the wave propagate til it reaches here, ellerno\n",
-    "sigma_x = 1.5\n",
-    "\n",
-    "# Normalization\n",
-    "C = 1/np.sqrt(\n",
-    "    np.sum(np.exp(-(x-x_s)**2/(sigma_x**2)))*dx\n",
-    ")\n",
-    "\n",
-    "v = np.zeros(N) # Zero potential\n",
-    "dt = 0.1 * h_bar / (h_bar**2 /(2*m*dx**2) + np.max(v)) # Timestep, much smaller than ..., see (12)\n",
-    "\n",
-    "'''Parameters for propagation'''\n",
-    "v_g = h_bar*k_0/m # group velocity\n",
-    "sim_time = L/(2*v_g) # simulation time\n",
-    "num_iter = int(sim_time/dt) # number of iterations\n",
-    "\n",
     "psi_re, psi_im = generate_psi()"
    ]
   },
@@ -188,7 +196,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def simulate(v, x_s, sigma_x, num_iter, psi_real, psi_imag):\n",
+    "def simulate(v, x_s, sigma_x, num_iter):\n",
     "    '''\n",
     "    Runs simulation for num_iter timesteps, using the timestep function.\n",
     "    \n",
@@ -197,8 +205,6 @@
     "        x_s: starting position\n",
     "        sigma_x: standard deviation for the Gaussian\n",
     "        num_iter: number of interations (timesteps)\n",
-    "        psi_real: vector for storing the real parts of the wave functions\n",
-    "        psi_imag: vector for storing the imaginary parts of the wave functions\n",
     "    Output:\n",
     "        psi_real: vector with the real parts of the WF at each timestep\n",
     "        psi_imag: vector with the imaginary parts of the WF at each timestep\n",
@@ -207,13 +213,12 @@
     "    np.sum(np.exp(-(x-x_s)**2/(sigma_x**2)))*dx\n",
     "    )\n",
     "    \n",
-    "    psi_real[0, 1:-1] = C*np.exp(-(x[1:-1]-x_s)**2/(2*sigma_x**2)) * np.cos(k_0*x[1:-1] - omega*dt/2)\n",
-    "    psi_imag[0, 1:-1] = C*np.exp(-(x[1:-1]-x_s)**2/(2*sigma_x**2)) * np.sin(k_0*x[1:-1])\n",
+    "    psi_re, psi_im = generate_psi(x_s=x_s, sigma_x=sigma_x, num_iter=num_iter)\n",
     "\n",
     "    for i in range(num_iter-1):\n",
-    "        psi_imag[i+1], psi_real[i+1] = timestep(psi_imag[i], psi_real[i], v, dt) #todo: pass more sensible dt\n",
+    "        psi_im[i+1], psi_re[i+1] = timestep(psi_im[i], psi_re[i], v, dt) #todo: pass more sensible dt\n",
     "        \n",
-    "    return psi_real, psi_imag"
+    "    return psi_re, psi_im"
    ]
   },
   {
@@ -223,7 +228,7 @@
    "outputs": [],
    "source": [
     "'''This cell runs the simulation'''\n",
-    "psi_re, psi_imag = simulate(v, x_s, sigma_x, num_iter, psi_re, psi_im)"
+    "psi_re, psi_im = simulate(v, x_s, sigma_x, num_iter)"
    ]
   },
   {
@@ -260,7 +265,7 @@
     "def init_anim():\n",
     "    #ax.plot(x, psi_re[0], psi_im[0])\n",
     "    global line\n",
-    "    line, = ax.plot(x, psi_re[0], psi_re[1])\n",
+    "    line, = ax.plot(x, psi_re[0], psi_im[0])\n",
     "    #ax.set_xlim([0, L])\n",
     "    #ax.set_ylim([-1, 1])\n",
     "    #ax.set_zlim([-1, 1])\n",
@@ -299,7 +304,6 @@
     "    line1.set_data(x, y[0])\n",
     "    line2.set_data(x, y[1])\n",
     "    \n",
-    "    \n",
     "fig, ax = plt.subplots()\n",
     "anim = animation.FuncAnimation(fig, animate, init_func=init_anim, frames=zip(psi_re[::100], psi_im[::100]), interval=60)\n",
     "plt.close(anim._fig)\n",
@@ -319,7 +323,7 @@
     "psi_im_sgms = np.zeros([len(sigma_xs), num_iter, N])\n",
     "\n",
     "for j in range(len(sigma_xs)):\n",
-    "    psi_re_sgms[j], psi_im_sgms[j] = simulate(v, x_s, sigma_xs[j], num_iter, psi_re, psi_im)"
+    "    psi_re_sgms[j], psi_im_sgms[j] = simulate(v, x_s, sigma_xs[j], num_iter)"
    ]
   },
   {
@@ -367,7 +371,7 @@
    "outputs": [],
    "source": [
     "'''Runs simulation with the barrier potential'''\n",
-    "psi_re, psi_im = simulate(v_barr, x_s, sigma_x, num_iter, psi_re, psi_im)"
+    "psi_re, psi_im = simulate(v_barr, x_s, sigma_x, num_iter)"
    ]
   },
   {
@@ -434,7 +438,7 @@
     "P_trans = []\n",
     "\n",
     "for f in fraction:\n",
-    "    psi_re, psi_im = simulate(f*v_barr, x_s, sigma_x, num_iter, psi_re, psi_im)\n",
+    "    psi_re, psi_im = simulate(f*v_barr, x_s, sigma_x, num_iter)\n",
     "    P_trans.append(np.sum((psi_re**2+psi_im**2)[-1, mid_i:])*dx)"
    ]
   },
@@ -456,7 +460,7 @@
     "# Find transmission probability as a function of barrier width\n",
     "v_0 =  9*E/10 # barrier height\n",
     "\n",
-    "widths = np.linspace(0, L/20, 50)\n",
+    "widths = np.geomspace(0.01, L/20, 50)\n",
     "P_trans = []\n",
     "\n",
     "#psi_re = np.zeros([num_iter, N])\n",
@@ -467,9 +471,9 @@
     "\n",
     "for l in widths:\n",
     "    v = v_0*np.heaviside(x*np.heaviside(-x +L/2 +l/2, 1) -L/2+l/2, 0)\n",
-    "    psi_re, psi_im = simulate(f*v, x_s, sigma_x, num_iter, psi_re, psi_im)\n",
+    "    psi_re, psi_im = simulate(f*v, x_s, sigma_x, num_iter)\n",
     "    P_trans.append(np.sum((psi_re**2+psi_im**2)[-1, mid_i:])*dx)\n",
-    "plt.plot(widths/L, P_trans) # Note that widths are plotted as fractions of L\n",
+    "plt.plot(widths/L, P_trans, 'o-') # Note that widths are plotted as fractions of L\n",
     "plt.show()"
    ]
   },
@@ -482,24 +486,16 @@
     "x_s = 5\n",
     "sigma_x = 1\n",
     "\n",
-    "# Arrays for storing psis at different points in time, need this later\n",
-    "psi_re = np.zeros([num_iter, N])\n",
-    "psi_im = np.zeros([num_iter, N])\n",
-    "\n",
-    "# see (8)\n",
-    "psi_re[0, 1:-1] = C*np.exp(-(x[1:-1]-x_s)**2/(2*sigma_x**2)) * np.cos(k_0*x[1:-1] - omega*dt/2)\n",
-    "psi_im[0, 1:-1] = C*np.exp(-(x[1:-1]-x_s)**2/(2*sigma_x**2)) * np.sin(k_0*x[1:-1])\n",
-    "\n",
     "'''Defines a barrier'''\n",
     "v_0 =  9*E/10 # barrier height\n",
-    "l_thin = 0 # barrier width\n",
+    "l_thin = L*0.002 # barrier width\n",
     "v_barr_thin = v_0*np.heaviside(x*np.heaviside(-x +L/2 +l_thin/2, 1) -L/2+l_thin/2, 0)\n",
-    "l_thick = L/20\n",
+    "l_thick = L*0.02\n",
     "v_barr_thick = v_0*np.heaviside(x*np.heaviside(-x +L/2 +l_thick/2, 1) -L/2+l_thick/2, 0)\n",
     "\n",
     "'''Runs simulation with the barrier potential'''\n",
-    "psi_re_thin, _ = simulate(v_barr_thin, x_s, sigma_x, num_iter, psi_re, psi_im)\n",
-    "psi_re_thick, _= simulate(v_barr_thick, x_s, sigma_x, num_iter, psi_re, psi_im)\n",
+    "psi_re_thin, _ = simulate(v_barr_thin, x_s, sigma_x, num_iter)\n",
+    "psi_re_thick, _= simulate(v_barr_thick, x_s, sigma_x, num_iter)\n",
     "\n",
     "'''Animation'''\n",
     "def init_anim():\n",
@@ -512,7 +508,7 @@
     "fig, ax = plt.subplots()\n",
     "#ax.plot(x, v_barr_thin)\n",
     "#ax.plot(x, v_barr_thick)\n",
-    "anim = animation.FuncAnimation(fig, animate, init_func=init_anim, frames=zip(0.2+psi_re_thin[::100], -0.2+psi_re_thick[::100]), interval=60)\n",
+    "anim = animation.FuncAnimation(fig, animate, init_func=init_anim, frames=zip(psi_re_thin[::100], psi_re_thick[::100]), interval=60)\n",
     "plt.close(anim._fig)\n",
     "HTML(anim.to_html5_video())"
    ]


### PR DESCRIPTION
…, in order to avoid confusion about overwriting values.

Overwriting/reusing psi caused an error in transmission vs. barrier height and transmission vs. barrier width, because psi was not
reset to initial value between each simulation